### PR TITLE
Remove duplicated call to `CompilerConfig()`

### DIFF
--- a/python/torchair/npu_export.py
+++ b/python/torchair/npu_export.py
@@ -26,7 +26,7 @@ def _get_model_weight_names(model: torch.nn.Module):
     return weight_name
 
 
-def _get_export_config(model, export_path: str, export_name: str, config=CompilerConfig()):
+def _get_export_config(model, export_path: str, export_name: str, config: CompilerConfig):
     config.export.export_mode = True
     config.export.export_path_dir = export_path
     config.export.export_name = export_name


### PR DESCRIPTION
**Description of the problem:**

The function `dynamo_export` initializes its argument `config` with `CompilerConfig()` and calls `_get_export_config` while passing the `config` to it. 

The function `_get_export_config` also initializes its `config` with `CompilerConfig()`. But `_get_export_config` is only called from within `dynamo_export`.

This results in a duplicated and unnecessary call to `CompilerConfig()`.

**Proposed solution:**

Remove `CompilerConfig()` call from `_get_export_config` argument initialization. Replace with type for keeping readability.